### PR TITLE
Kjonick projectAsCode Fix

### DIFF
--- a/src/project/project.xml.in
+++ b/src/project/project.xml.in
@@ -9604,6 +9604,7 @@ $ec-&gt;setProperty("/projects/$[Project]/ec_visibility", "pickListOnly");
         <stepName>deleteExportedProject</stepName>
         <alwaysRun>0</alwaysRun>
         <broadcast>0</broadcast>
+        <condition>$[/javascript myProcedure.disableCleanup == true]</condition>
         <condition/>
         <description/>
         <errorHandling>failProcedure</errorHandling>

--- a/src/project/project.xml.in
+++ b/src/project/project.xml.in
@@ -9125,32 +9125,26 @@ Changelog:
                     </property>
                   </propertySheet>
                 </property>
-                
-                
-                                <property>
+                <property>
                   <propertyName>disableCleanup</propertyName>
-                                 <propertySheet>
-                                     <property>
+                  <propertySheet>
+                    <property>
                       <propertyName>checkedValue</propertyName>
-                      
                       <expandable>1</expandable>
-                                         <value>true</value>
+                      <value>true</value>
                     </property>
                     <property>
                       <propertyName>formType</propertyName>
-                      
                       <expandable>1</expandable>
-                                         <value>standard</value>
+                      <value>standard</value>
                     </property>
                     <property>
                       <propertyName>initiallyChecked</propertyName>
-                      
                       <expandable>1</expandable>
-                                         <value>1</value>
+                      <value>1</value>
                     </property>
                     <property>
                       <propertyName>uncheckedValue</propertyName>
-      
                       <expandable>1</expandable>
                       <value>false</value>
                     </property>

--- a/src/project/project.xml.in
+++ b/src/project/project.xml.in
@@ -9125,6 +9125,37 @@ Changelog:
                     </property>
                   </propertySheet>
                 </property>
+                
+                
+                                <property>
+                  <propertyName>disableCleanup</propertyName>
+                                 <propertySheet>
+                                     <property>
+                      <propertyName>checkedValue</propertyName>
+                      
+                      <expandable>1</expandable>
+                                         <value>true</value>
+                    </property>
+                    <property>
+                      <propertyName>formType</propertyName>
+                      
+                      <expandable>1</expandable>
+                                         <value>standard</value>
+                    </property>
+                    <property>
+                      <propertyName>initiallyChecked</propertyName>
+                      
+                      <expandable>1</expandable>
+                                         <value>1</value>
+                    </property>
+                    <property>
+                      <propertyName>uncheckedValue</propertyName>
+      
+                      <expandable>1</expandable>
+                      <value>false</value>
+                    </property>
+                  </propertySheet>
+                </property>
                 <property>
                   <propertyName>fixSelfReferences</propertyName>
                   <propertySheet>


### PR DESCRIPTION
Here is a workaround that we are implementing on our side for issue #30.  We created a checkbox to determine if cleanup of the project should occur or not.  If checked, then the deleteExportedProject step will be skipped.